### PR TITLE
fix for merged tiles not removed after vertical move

### DIFF
--- a/gofusion.qml
+++ b/gofusion.qml
@@ -146,7 +146,13 @@ Rectangle {
                 }
             }
             Behavior on y  {
-                NumberAnimation  { duration: 500; easing.type: Easing.OutBounce }
+                NumberAnimation  { duration: 500; easing.type: Easing.OutBounce; 
+                    onRunningChanged: {
+                        if (!running) {
+                            ctrl.handleMoveAnimationDone();
+                        }
+                    } 
+                }
             }
             Behavior on width  {
                 NumberAnimation  { duration: 500; easing.type: Easing.OutBounce }


### PR DESCRIPTION
On a vertical move, when tiles are joined, the old tiles are not removed, and cover the new tile. The old tiles are only removed after a horizontal move.
This pull request fixes this.
This is with Qt 5.5.1
